### PR TITLE
change key_server from keys.gnupg.net to keyserver.ubuntu.com

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -13,7 +13,7 @@ action :install do
   include_recipe 'ruby_rvm'
   Chef::Log.info "Install GPG key for RVM for user #{new_resource.user}"
   bsw_gpg_load_key_from_key_server 'rvm_key' do
-    key_server 'keys.gnupg.net'
+    key_server 'keyserver.ubuntu.com'
     key_id 'D39DC0E3'
     for_user new_resource.user
   end


### PR DESCRIPTION
I got the following error so changed. 

Converge failed with error message ruby_rvm[jenkins](w_jenkins::default line 6) had an error: RuntimeError: bsw_gpg_load_key_from_key_server[rvm_key](/tmp/vagrant-chef/98987cba840e8ed3f00b00baf749d944/cookbooks/ruby_rvm/providers/default.rb line 15) had an error: RuntimeError: Unable to contact key server 'http://keys.gnupg.net:11371/pks/lookup?options=mr&op=get&search=0xD39DC0E3', details: getaddrinfo: Name or service not known
