### PR TITLE
Fixed 'User ruby installation skips if [:rvm][:user][:rubies] defined

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures rvm'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 # source_url 'https://github.com/MurgaNikolay/chef-rvm'
 # issues_url 'https://github.com/MurgaNikolay/chef-rvm/issues'
-version '0.4.9'
+version '0.4.10'
 
 recipe 'ruby_rvm', 'Installs all'
 recipe 'ruby_rvm::rvm', 'Installs the rvm for users'

--- a/recipes/rubies.rb
+++ b/recipes/rubies.rb
@@ -1,6 +1,6 @@
 include_recipe 'ruby_rvm::packages'
 node['rvm']['users'].each do |username, rvm_settings|
-  next if rvm_settings['rubies']
+  next if not rvm_settings['rubies']
   rubies = rvm_settings['rubies']
   rubies = Array(rubies) if rubies.is_a?(String)
   rubies.each do |version, action|


### PR DESCRIPTION
If user ruby is defined, its installation doesn't happen, because conditions forces to skip current cycle iteration.
