### PR TITLE
Specified rvm path on the command line

### DIFF
--- a/libraries/rvm_simple_environment_rvm.rb
+++ b/libraries/rvm_simple_environment_rvm.rb
@@ -44,7 +44,7 @@ class ChefRvmCookbook
         begin
           parent_shell_out("curl -sSL https://get.rvm.io > #{temp_file.path}").error!
           parent_shell_out("chmod 0777 #{temp_file.path}").error!
-          parent_shell_out("bash #{temp_file.path} stable --auto-dotfiles", shell_options).error!
+          parent_shell_out("bash #{temp_file.path} stable --auto-dotfiles --path '#{rvm_path}'", shell_options).error!
           rvm('autolibs read-fail')
         ensure
           temp_file.close


### PR DESCRIPTION
Hi! rvm was acting strange on my system, completely ignoring rvm_path environment variable and trying to install itself into /usr/local without sufficient privileges. Specifying rvm path on the command line fixed that.