### PR TITLE
Fix chef 13 compatibility and remove GPG dependency

### DIFF
--- a/libraries/requirements.rb
+++ b/libraries/requirements.rb
@@ -69,8 +69,8 @@ class ChefRvmCookbook
         },
         'suse' => {
           'default' => %w( automake binutils bison bzip2 libtool m4 make patch gdbm-devel glibc-devel libffi-devel
-                  libopenssl-devel readline-devel zlib-devel sqlite3-devel
-                  gcc-c++ zlib libxml2-devel libxslt-devel llvm llvm-clang llvm-devel )
+						   libopenssl-devel readline-devel zlib-devel sqlite3-devel
+						   gcc-c++ zlib libxml2-devel libxslt-devel llvm llvm-clang llvm-devel )
         },
         %w(centos redhat fedora scientific amazon) => {
           'default' => %w(gcc-c++ patch readline readline-devel zlib zlib-devel

--- a/libraries/requirements.rb
+++ b/libraries/requirements.rb
@@ -68,9 +68,9 @@ class ChefRvmCookbook
                           patch ca-certificates curl libncurses5-dev)
         },
         'suse' => {
-          'default' => %w( automake binutils bison bzip2 libtool m4 make patch gdbm-devel glibc-devel libffi-devel
-						   libopenssl-devel readline-devel zlib-devel sqlite3-devel
-						   gcc-c++ zlib libxml2-devel libxslt-devel llvm llvm-clang llvm-devel )
+          'default' => %w(automake binutils bison bzip2 libtool m4 make patch gdbm-devel glibc-devel libffi-devel
+                          libopenssl-devel readline-devel zlib-devel sqlite3-devel
+                          gcc-c++ zlib libxml2-devel libxslt-devel llvm llvm-clang llvm-devel )
         },
         %w(centos redhat fedora scientific amazon) => {
           'default' => %w(gcc-c++ patch readline readline-devel zlib zlib-devel

--- a/libraries/rvm_provider_mixin.rb
+++ b/libraries/rvm_provider_mixin.rb
@@ -2,8 +2,8 @@ class ChefRvmCookbook
   module RvmProviderMixin
     def rvm
       @rvm ||= ChefRvmCookbook::RvmSimpleEnvironment.new(new_resource.user,
-        verbose: node['chef_rvm']['verbose'],
-        keyserver: node['chef_rvm']['keyserver']
+														 verbose: node['chef_rvm']['verbose'],
+														 keyserver: node['chef_rvm']['keyserver']
       )
     end
   end

--- a/libraries/rvm_provider_mixin.rb
+++ b/libraries/rvm_provider_mixin.rb
@@ -2,8 +2,8 @@ class ChefRvmCookbook
   module RvmProviderMixin
     def rvm
       @rvm ||= ChefRvmCookbook::RvmSimpleEnvironment.new(new_resource.user,
-														 verbose: node['chef_rvm']['verbose'],
-														 keyserver: node['chef_rvm']['keyserver']
+                                                         verbose: node['chef_rvm']['verbose'],
+                                                         keyserver: node['chef_rvm']['keyserver']
       )
     end
   end

--- a/libraries/rvm_simple_environment_rvm.rb
+++ b/libraries/rvm_simple_environment_rvm.rb
@@ -37,9 +37,6 @@ class ChefRvmCookbook
       end
 
       def rvm_install
-        cmd = parent_shell_out("gpg --keyserver #{options[:keyserver] || 'hkp://keyserver.ubuntu.com'} --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3", shell_options)
-        cmd.error!
-
         temp_file = Tempfile.new('foo')
         begin
           parent_shell_out("curl -sSL https://get.rvm.io > #{temp_file.path}").error!

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures rvm'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 # source_url 'https://github.com/MurgaNikolay/chef-rvm'
 # issues_url 'https://github.com/MurgaNikolay/chef-rvm/issues'
-version '1.1.0'
+version '1.1.1'
 
 recipe 'chef_rvm', 'Installs all'
 recipe 'chef_rvm::rvm', 'Installs the rvm for users'
@@ -23,7 +23,6 @@ depends 'sudo'
 depends 'apt'
 depends 'build-essential'
 depends 'chef_gem'
-depends 'gpg'
 depends 'curl'
 
 # if using jruby, java is required on system

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -1,4 +1,3 @@
-include_recipe 'gpg'
 include_recipe 'apt'
 include_recipe 'build-essential'
 include_recipe 'curl'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,6 +1,6 @@
 actions :install, :implode, :upgrade
 default_action :install
-attribute :user, kind_of: [String, NilClass], name_attribute: true, default: 'root'
+attribute :user, kind_of: [String, NilClass], name_attribute: true
 attribute :rubies, kind_of: [Hash, Array, String], :default => {}
 attribute :rvmrc, kind_of: [Hash, NilClass], :default => nil
 


### PR DESCRIPTION
Fixed error mentioned in #10 
removed GPG dependency as was causing issues due to wrong permissions on files and looking through the code and the RVM install script it was not necessary